### PR TITLE
Added Access Check to permalink Shortcode

### DIFF
--- a/inc/core/shortcodes.php
+++ b/inc/core/shortcodes.php
@@ -852,7 +852,6 @@ class Su_Shortcodes {
 		} else {
 			return $text;
 		}
-		}
 	}
 
 	public static function members( $atts = null, $content = null ) {

--- a/inc/core/shortcodes.php
+++ b/inc/core/shortcodes.php
@@ -847,7 +847,12 @@ class Su_Shortcodes {
 		$atts['id'] = su_scattr( $atts['id'] );
 		// Prepare link text
 		$text = ( $content ) ? $content : get_the_title( $atts['id'] );
-		return '<a href="' . get_permalink( $atts['id'] ) . '" class="' . su_ecssc( $atts ) . '" title="' . $text . '" target="_' . $atts['target'] . '">' . $text . '</a>';
+		if (current_user_can('read',$atts['id'])) {
+			return '<a href="' . get_permalink( $atts['id'] ) . '" class="' . su_ecssc( $atts ) . '" title="' . $text . '" target="_' . $atts['target'] . '">' . $text . '</a>';
+		} else {
+			return $text;
+		}
+		}
 	}
 
 	public static function members( $atts = null, $content = null ) {


### PR DESCRIPTION
The permalink shortcode will return a simple text instead of a link if the user has no rights to access the link target.
