### PR TITLE
Enhancement to retrieve post by slug

### DIFF
--- a/inc/core/shortcodes.php
+++ b/inc/core/shortcodes.php
@@ -1267,6 +1267,7 @@ class Su_Shortcodes {
 			// Term string to array
 			$tax_term = explode( ',', $tax_term );
 			// Validate operator
+			$tax_operator = str_replace( array( 0, 1, 2 ), array( 'IN', 'NOT IN', 'AND' ), $tax_operator );
 			if ( !in_array( $tax_operator, array( 'IN', 'NOT IN', 'AND' ) ) ) $tax_operator = 'IN';
 			$tax_args = array( 'tax_query' => array( array(
 						'taxonomy' => $taxonomy,


### PR DESCRIPTION
The 'post' shortcode now accepts attributes "slug" and an optional "post_type" as an alternative to "post_id". This allows reference to a post by name rather than having to know the ID number, making the shortcode more readable. If data is moved into another system, the shortcode won't break even though the ID has changed, eliminating some post-migration hassle. 

If not present the default post_type is "page".

Working examples taken from live code:
- [su_post field="post_content" default="About post or description not found" slug="about"]
- [su_post field="ct_Short_Ad_textarea_a84a" default="Information about Chat Features is not available." slug="chat" post_type="gcc_feature"]

The first shortcode is for the 'about' 'page'. The second shortcode is for a custom post type, a 'gcc_feature', where each post describes a different feature of the site, and 'chat' is one of the feature offered. The field is of course unique to that type. It should seem apparent that referring to the feature called chat is much more intuitive than post ID 441.
